### PR TITLE
Small tweaks to your Git Bash fixes for autojump

### DIFF
--- a/bin/autojump.bash
+++ b/bin/autojump.bash
@@ -112,6 +112,9 @@ jo() {
             cygwin)
                 cygstart "" $(cygpath -w -a ${output})
                 ;;
+            msys)
+                start "${output}"
+                ;;
             *)
                 echo "Unknown operating system: ${OSTYPE}." 1>&2
                 ;;

--- a/install.py
+++ b/install.py
@@ -20,7 +20,7 @@ def cp(src, dest, dryrun=False):
 
 
 def in_bash():
-    return get_shell() == 'bash'
+    return get_shell().startswith('bash')
 
 
 def in_msysgit():


### PR DESCRIPTION
Not sure why, but `os.getenv('SHELL', '')` returns `bash.exe` for me. Python 3?

Also, the `jo` command needed tweaking for OSTYPE=msys.